### PR TITLE
Fix undefined `link` in debug

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -155,7 +155,7 @@ Client.prototype = {
 
       if( response.headers[ 'link' ] ) {
         response.link = HTTPLink.parse( response.headers[ 'link' ] )
-        debug( 'http:response:link', link )
+        debug( 'http:response:link', response.link )
       }
 
       callback.call( self, error, response, body )


### PR DESCRIPTION
We ran into this bug, looked like an easy fix.

As an unrelated side note, due to the breaking change in https://github.com/jhermsmeier/node-acme-protocol/commit/f85c2543f563c4c80b5636ec281250432d295580 I would recommend a major or at least minor version update.